### PR TITLE
Fix RoleSeeder

### DIFF
--- a/jorn_api/database/seeders/RoleSeeder.php
+++ b/jorn_api/database/seeders/RoleSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
@@ -13,6 +14,6 @@ class RoleSeeder extends Seeder
      */
     public function run(): void
     {
-        Role::create(['name' => 'employee']);
+        Role::create(['id' => Str::uuid(), 'name' => 'employee']);
     }
 }


### PR DESCRIPTION
Cuando una table (en este caso 'roles') maneja UUID en vez de AUTOINCREMENTAL_ID, en su seeder se necesita especificar que es de tipo UUID para que sea aleatorio (por defecto lo interpreta como un id normal).

Es por eso, que al clonar el repo y hacer la migración con seeders me daba error:
![image](https://github.com/user-attachments/assets/b182ef84-0708-47f7-ae82-30e0bd8824ef)

Y con este pequeño cambio, hace la migración con el seeder correctamente:
![image](https://github.com/user-attachments/assets/5133e79d-6277-4f3f-a9b2-18e8b5b7145f)

Saludos Pupa! 